### PR TITLE
Better interpretation of schema in parameter list

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,21 @@
+language: node_js
+node_js:
+  - "stable"
+
+cache:
+  directories:
+    - "node_modules"
+
+script: npm run build
+
+before_deploy:
+  -  tar -zcvf ../build-${TRAVIS_BUILD_NUMBER}.tar.gz -C . --exclude ./node_modules --exclude ./.git .
+
+deploy:
+  - provider: releases
+    api_key:
+      secure: ${GITHUB_API_KEY}
+    file: ../build-${TRAVIS_BUILD_NUMBER}.tar.gz
+    skip_cleanup: true
+    on:
+      tags: true

--- a/templates/angular2-service.mustache
+++ b/templates/angular2-service.mustache
@@ -46,7 +46,7 @@ export class ApiClientService {
   {{/parameters}}
   * @return Full HTTP response as Observable
   */
-  public {{&methodName}}({{#parameters}}{{&camelCaseName}}: {{typescriptType}}{{^isLast}}, {{/isLast}}{{/parameters}}): Observable<HttpResponse<{{&response}}>> {
+  public {{&methodName}}({{#parameters}}{{&camelCaseName}}{{^required}}?{{/required}}: {{typescriptType}}{{^isLast}}, {{/isLast}}{{/parameters}}): Observable<HttpResponse<{{&response}}>> {
     const uri = `{{&backTickPath}}`;
     {{#hasHeaderParameters}}
     let headers = new HttpHeaders();

--- a/templates/angular2-service.mustache
+++ b/templates/angular2-service.mustache
@@ -27,9 +27,9 @@ export enum {{name}} {
 @Injectable()
 export class ApiClientService {
 
-  private domain = '{{&domain}}';
+  protected domain = '{{&domain}}';
 
-  constructor(private http: HttpClient, @Optional() @Inject('domain') domain: string ) {
+  constructor(protected http: HttpClient, @Optional() @Inject('domain') domain: string ) {
     if (domain) {
       this.domain = domain;
     }
@@ -109,7 +109,7 @@ export class ApiClientService {
   }
 
 {{/methods}}
-  private sendRequest<T>(method: string, uri: string, headers: HttpHeaders, params: HttpParams, body: any): Observable<HttpResponse<T>> {
+  protected sendRequest<T>(method: string, uri: string, headers: HttpHeaders, params: HttpParams, body: any): Observable<HttpResponse<T>> {
     if (method === 'get') {
       return this.http.get<T>(this.domain + uri, { headers: headers.set('Accept', 'application/json'), params: params, observe: 'response' });
     } else if (method === 'options') {

--- a/templates/angular2-service.mustache
+++ b/templates/angular2-service.mustache
@@ -112,10 +112,14 @@ export class ApiClientService {
   private sendRequest<T>(method: string, uri: string, headers: HttpHeaders, params: HttpParams, body: any): Observable<HttpResponse<T>> {
     if (method === 'get') {
       return this.http.get<T>(this.domain + uri, { headers: headers.set('Accept', 'application/json'), params: params, observe: 'response' });
+    } else if (method === 'options') {
+      return this.http.options<T>(this.domain + uri, { headers: headers.set('Accept', 'application/json'), params: params, observe: 'response' });
     } else if (method === 'put') {
       return this.http.put<T>(this.domain + uri, body, { headers: headers.set('Content-Type', 'application/json'), params: params, observe: 'response' });
     } else if (method === 'post') {
       return this.http.post<T>(this.domain + uri, body, { headers: headers.set('Content-Type', 'application/json'), params: params, observe: 'response' });
+    } else if (method === 'patch') {
+      return this.http.patch<T>(this.domain + uri, body, { headers: headers.set('Content-Type', 'application/json'), params: params, observe: 'response' });
     } else if (method === 'delete') {
       return this.http.delete<T>(this.domain + uri, { headers: headers, params: params, observe: 'response' });
     } else {


### PR DESCRIPTION
In the original implementation types that are referenced using the `schema` attribute were only recognised if the schema referenced to a class. Otherwise the type would have have been an empty string which caused compiler errors.

I modified to code to support the following definitions:

```
{
    "in": "body",
    "name": "foo",
    "description": "foo",
    "required": true,
    "schema": {
        "type": "string"
    }
}
```

and

```
{
    "in": "body",
    "name": "bar",
    "description": "bar",
    "required": true,
    "schema": {
        "type": "array",
        "items": {
            "$ref": "#/definitions/FooObj"
        }
    }
}
```

If no type can be found it will also be set to `any` to avoid compiler errors.